### PR TITLE
feat: try and improve Claude's trailing newline detection

### DIFF
--- a/.agents/rules/shared/code-review.md
+++ b/.agents/rules/shared/code-review.md
@@ -43,7 +43,7 @@ Apply relevant areas based on repository content type - code repositories focus 
 - **Naming conventions**: Check for clear, non-abbreviated variable and function names
 - **Code spacing**: Ensure logical separation of code blocks
 - **Comments**: Verify comments explain reasoning, not redundant information
-- **Text files**: Ensure files end with trailing newline
+- **Text files**: Ensure files end with trailing newline, detect this based on whether you see "No newline at end of file" in `git diff` output, you cannot tell whether it is correct just from reading the file
 
 ### Documentation Accuracy
 - **When documentation includes command examples**: Validate CLI commands by testing them in the appropriate environment (e.g., OS, shell, toolchain version) where feasible, and verify they work as documented for the described use cases.


### PR DESCRIPTION
I noticed that it has incorrectly identified files as missing a trailing newline a few times. It's really not capable of detecting this based on file content, so instead it should just trust the diff output which reliably detects when this happens.

Tested this branch in a private PR.