### PR TITLE
feat: grant claude-review access to more CI mcp tools and inline comments

### DIFF
--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -59,6 +59,8 @@ runs:
           "
           --allowedTools "
             mcp__github_ci__get_ci_status,
+            mcp__github_ci__get_workflow_run_details,
+            mcp__github_ci__download_job_log,
             mcp__github_inline_comment__create_inline_comment,
             Bash(gh pr comment:*),
             Bash(gh pr diff:*),

--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -14,6 +14,10 @@ runs:
         GH_TOKEN: ${{ github.token }}
 
     - uses: anthropics/claude-code-action@v1
+      env:
+        GH_API_COMMENTS_COMMAND: >-
+          ${{ github.action_path }}/gh-pr-comments.sh
+          ${{ github.event.pull_request.number || github.event.issue.number }}
       with:
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
 
@@ -26,8 +30,13 @@ runs:
 
           Note: The PR branch is already checked out in the current working directory.
 
-          IMPORTANT: Before starting your review, use `gh pr view --json title,body,files,additions,deletions,comments`
-          to read details including existing comments on this PR.
+          IMPORTANT: Before starting your review, read the details including reviews and inline comments
+          (use exactly these commands, do not substitute variables):
+          ```
+          gh pr view --json title,body,files,additions,deletions,comments
+          ${{ env.GH_API_COMMENTS_COMMAND }}
+          ```
+
           Check for any issues that have already been identified by previous reviews.
           Only comment on new issues that haven't been previously noted.
 
@@ -64,5 +73,6 @@ runs:
             mcp__github_inline_comment__create_inline_comment,
             Bash(gh pr comment:*),
             Bash(gh pr diff:*),
-            Bash(gh pr view:*)
+            Bash(gh pr view:*),
+            Bash(${{ env.GH_API_COMMENTS_COMMAND }}),
           "

--- a/.github/actions/claude-review/gh-pr-comments.sh
+++ b/.github/actions/claude-review/gh-pr-comments.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+query='.[] | pick(.path, .user.login, .body, .original_commit_id, .diff_hunk)'
+
+gh api "repos/{owner}/{repo}/pulls/$1/comments" -q "$query"


### PR DESCRIPTION
Gives access to more details on CI results if claude needs to investigate them.

The `gh pr view` command only shows top-level comments, missing out on the inline review comments. This means that claude keeps repeating comments that have already been made.

Adds a small script with a very focused `gh api` command to query inline comments too. This needs to be a separate script as the `allowed-tools` config seems to have trouble parsing the full command if it's just specified inline, and `gh api` is too powerful not to restrict it to this exact command.