### PR TITLE
feat: add `dep-diff.sh` for upstream dependency source auditing

### DIFF
--- a/.agents/rules/shared/code-review.md
+++ b/.agents/rules/shared/code-review.md
@@ -92,3 +92,28 @@ Apply relevant areas based on repository content type - code repositories focus 
 - Additional cross-references between sections
 - Minor markdown formatting improvements
 - Enhanced examples or more detailed explanations
+
+## Dependency Update Reviews
+
+**When to apply:** PRs containing version bumps in dependency manifests or lockfiles, typically opened by dependabot or renovate.
+
+### Workflow
+
+1. **Extract upstream repo and refs** from the PR body — dependabot/renovate include the GitHub repository and version tags in the PR description.
+2. **Fetch upstream changes** using the `dep-diff.sh` script:
+   ```
+   dep-diff.sh <owner/repo> <old-ref> <new-ref> <tmp-dir>
+   ```
+   This writes two files and prints their paths and line counts.
+3. **Read the `.log` file first** to understand scope: how many commits, what areas were touched, whether the change is focused or sprawling.
+4. **Read the `.diff` file** to audit actual source changes.
+   For large diffs, use the `.log` to identify areas of concern and selectively read relevant sections of the `.diff` — focus on public API surface, build configuration, and security-sensitive files.
+
+### What to Audit
+
+- **Breaking API changes** that could affect consuming code
+- **Language specific concerns** e.g. `unsafe` code in Rust
+- **Build scripts** — new or modified `build.rs`, `Makefile`, post-install scripts, or similar
+- **New dependencies** added by the upstream project (check their `Cargo.toml`, `package.json`, etc.)
+- **Unexpected scope** — changes unrelated to the stated purpose of the release
+- **Supply chain concerns** — binary blobs, obfuscated code, pre-built artifacts

--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -108,6 +108,7 @@ runs:
             Bash(gh pr diff:*),
             Bash(gh pr view:*),
             Bash(${{ env.GH_API_COMMENTS_COMMAND }}),
+            Bash(${{ github.action_path }}/dep-diff.sh:*),
             Write,
           "
 

--- a/.github/actions/claude-review/dep-diff.sh
+++ b/.github/actions/claude-review/dep-diff.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Fetch the source diff and commit log between two refs of a GitHub repository.
+#
+# Usage: dep-diff.sh <owner/repo> <base-ref> <head-ref> <output-dir>
+#
+# Outputs:
+#   <output-dir>/<repo>-<base>..<head>.diff  — raw source diff
+#   <output-dir>/<repo>-<base>..<head>.log   — commit messages with diffstats
+#
+# Prints the path and line count of each output file to stdout.
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "Usage: dep-diff.sh <owner/repo> <base-ref> <head-ref> <output-dir>" >&2
+  exit 1
+fi
+
+repo="$1"
+base="$2"
+head="$3"
+output_dir="$4"
+
+if [[ ! -d "$output_dir" ]]; then
+  echo "Error: output directory does not exist: $output_dir" >&2
+  exit 1
+fi
+
+# Sanitize for filenames: owner/repo -> owner-repo, and escape any odd chars in refs.
+safe_repo="${repo//\//-}"
+safe_base="${base//\//-}"
+safe_head="${head//\//-}"
+prefix="${output_dir}/${safe_repo}-${safe_base}..${safe_head}"
+
+diff_file="${prefix}.diff"
+log_file="${prefix}.log"
+
+# Fetch raw diff.
+if ! gh api "repos/${repo}/compare/${base}...${head}" \
+  -H 'Accept: application/vnd.github.v3.diff' \
+  > "$diff_file" 2>/dev/null; then
+  echo "Error: failed to fetch diff for ${repo} ${base}...${head}" >&2
+  echo "Check that the repository and refs exist." >&2
+  rm -f "$diff_file"
+  exit 1
+fi
+
+# Fetch compare JSON for commit messages and stats.
+compare_json="${prefix}.json"
+if ! gh api "repos/${repo}/compare/${base}...${head}" \
+  > "$compare_json" 2>/dev/null; then
+  echo "Error: failed to fetch compare data for ${repo} ${base}...${head}" >&2
+  rm -f "$compare_json"
+  exit 1
+fi
+
+# Build the log file from the JSON response.
+jq -r '
+  # Overall diffstat summary.
+  "\(.total_commits) commits, " +
+    "\(.files | length) files changed, " +
+    "\([.files[].additions] | add // 0) insertions(+), " +
+    "\([.files[].deletions] | add // 0) deletions(-)",
+  "",
+  # Per-file diffstat.
+  (.files[] |
+    "  \(.additions)\t\(.deletions)\t\(.filename)" +
+    (if .previous_filename then " (renamed from \(.previous_filename))" else "" end)
+  ),
+  "",
+  # Commit messages.
+  (.commits[] |
+    (.sha[:8]) + " " + .commit.message,
+    ""
+  )
+' "$compare_json" > "$log_file"
+
+rm -f "$compare_json"
+
+diff_lines=$(wc -l < "$diff_file")
+log_lines=$(wc -l < "$log_file")
+
+echo "${diff_file} (${diff_lines} lines)"
+echo "${log_file} (${log_lines} lines)"


### PR DESCRIPTION
Add constrained script to fetch source-level diffs and commit logs between two refs of a GitHub repository via `gh api`. Outputs `.diff` and `.log` files for the reviewing agent to read.

Add "Dependency Update Reviews" section to shared `code-review.md` covering workflow and audit checklist for dependency update PRs.