### PR TITLE
chore: note `dep-diff.sh` location

### DIFF
--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -83,6 +83,7 @@ runs:
           accuracy, content quality, and structural organization according to your established review priorities.
 
           Use `${{ runner.temp }}/claude-tmp` to store temporary files
+          `dep-diff.sh` is at `${{ github.action_path }}/dep-diff.sh`
 
           To send top-level comments write them to a temporary file first,
           then use `gh pr comment --body-file the-temp-file.txt` (avoids shell backtick/quote escaping issues).


### PR DESCRIPTION
I have seen it using the wrong base path for this.