### PR TITLE
chore: workaround claude-code-action `--add-dir` bug

### DIFF
--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -96,6 +96,10 @@ runs:
           --model opus
           --add-dir "${{ github.action_path }}/../../.."
           --add-dir "${{ runner.temp }}/claude-tmp"
+          # Workaround for <https://github.com/anthropics/claude-code-action/issues/1215>, since we can only have one
+          # additional directory, make it the runner root. The other paths are like `/home/runner/work/_actions/...`,
+          # `/home/runner/work/_temp/...` when running on GitHub-hosted runners
+          --add-dir "/home/runner/work"
           --append-system-prompt "
             Read @${{ github.action_path }}/../../../.agents/rules/shared/AGENTS.md for organizational guidelines.
           "


### PR DESCRIPTION
I noticed some failures reading from the `style-guide` paths, took a while to track down this is a bug in the action silently dropping some of our `--add-dir` flags. As an overly broad hack for now grant access to the entire work directory till it is fixed.