### PR TITLE
Update Claude review/assistant model to Fable 5

### DIFF
--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -102,7 +102,7 @@ runs:
           post a brief note like "✅ Review complete - no new issues found".
 
         claude_args: |
-          --model opus
+          --model fable
           --add-dir "${{ steps.checkout-pr.outputs.style-guide-base }}"
           --add-dir "${{ runner.temp }}/claude-tmp"
           --append-system-prompt "

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -22,7 +22,7 @@ runs:
           actions: read
 
         claude_args: |
-          --model opus
+          --model fable
           --add-dir "${{ github.action_path }}/../../.."
           --append-system-prompt "
             Read @${{ github.action_path }}/../../../.agents/rules/shared/AGENTS.md for organizational guidelines.


### PR DESCRIPTION
## Summary
Both the `claude-review` (PR review bot) and `claude` (@claude mention assistant) composite actions were pinned to `--model opus`. Updated both to `--model fable`.

## Why
Claude Fable 5 (`claude-fable-5`) is Anthropic's most capable generally available model, above the Opus tier. It was suspended June 12 under export controls and restored globally July 1, 2026. Confirmed via Anthropic's docs that `fable` is a valid `--model` alias for the Claude Code CLI (same form as the existing `opus`/`sonnet`/`haiku` aliases).

## Changes
- `.github/actions/claude-review/action.yml`: `--model opus` → `--model fable`
- `.github/actions/claude/action.yml`: `--model opus` → `--model fable`