### PR TITLE
ci: force Claude subagents to run in the foreground

### DIFF
--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -40,6 +40,10 @@ runs:
 
     - uses: anthropics/claude-code-action@v1
       env:
+        # Force subagents to run in the foreground so the main agent blocks on
+        # their results instead of exiting while they run in the background.
+        # See https://github.com/anthropics/claude-code-action/issues/1462
+        CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
         GH_API_COMMENTS_COMMAND: >-
           ${{ github.action_path }}/gh-pr-comments.sh
           ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/.github/actions/claude/action.yml
+++ b/.github/actions/claude/action.yml
@@ -12,6 +12,11 @@ runs:
 
   steps:
     - uses: anthropics/claude-code-action@v1
+      env:
+        # Force subagents to run in the foreground so the main agent blocks on
+        # their results instead of exiting while they run in the background.
+        # See https://github.com/anthropics/claude-code-action/issues/1462
+        CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
       with:
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
 


### PR DESCRIPTION
Set `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in both composite Claude actions so subagents run in the foreground. In headless CI the main agent can otherwise end its turn while a background subagent is still running, killing the background work and reporting a false `success`.