### PR TITLE
fix(actions): document allowed `Bash` commands in review prompt

### DIFF
--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -106,9 +106,9 @@ runs:
           ${{ env.GH_API_COMMENTS_COMMAND }}
           ${{ github.action_path }}/dep-diff.sh ...
           ```
-          Every other command (including `git`, `cat`, `ls`, `grep`, `find`, pipes into other tools, etc.)
-          is denied and will fail. Use `Read`, `Grep`, `Glob` and the MCP tools instead,
-          and never try to work around a denied command.
+          Commands not listed above (including `git`, `cat`, `ls`, `grep`, `find`, pipes into other tools, etc.)
+          are not allowlisted: read-only commands may still run sandboxed, but anything else will be denied.
+          Prefer `Read`, `Write` and the MCP tools where possible, and never try to work around a denied command.
 
           To send top-level comments write them to a temporary file first,
           then use `gh pr comment --body-file the-temp-file.txt` (avoids shell backtick/quote escaping issues).

--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -97,6 +97,19 @@ runs:
           Use `${{ runner.temp }}/claude-tmp` to store temporary files
           `dep-diff.sh` is at `${{ github.action_path }}/dep-diff.sh`
 
+          IMPORTANT: The only `Bash` commands you are allowed to run are the ones explicitly mentioned
+          in this prompt:
+          ```
+          gh pr comment ...
+          gh pr diff ...
+          gh pr view ...
+          ${{ env.GH_API_COMMENTS_COMMAND }}
+          ${{ github.action_path }}/dep-diff.sh ...
+          ```
+          Every other command (including `git`, `cat`, `ls`, `grep`, `find`, pipes into other tools, etc.)
+          is denied and will fail. Use `Read`, `Grep`, `Glob` and the MCP tools instead,
+          and never try to work around a denied command.
+
           To send top-level comments write them to a temporary file first,
           then use `gh pr comment --body-file the-temp-file.txt` (avoids shell backtick/quote escaping issues).
           Use `mcp__github_inline_comment__create_inline_comment` to highlight specific areas of concern.


### PR DESCRIPTION
The review agent has all other `Bash` calls denied, so spell out the permitted commands and point it at `Read`/`Grep`/`Glob` instead.

This should help to avoid it commonly attempting to perform other actions while reviewing code.